### PR TITLE
Extended functionality to support additional annotations

### DIFF
--- a/src/main/java/com/dguner/lombokbuilderhelper/LombokBuilderInspection.java
+++ b/src/main/java/com/dguner/lombokbuilderhelper/LombokBuilderInspection.java
@@ -21,7 +21,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -102,12 +101,12 @@ public class LombokBuilderInspection extends AbstractBaseJavaLocalInspectionTool
         final String defaultBuilderValueAnnotation = "lombok.Builder.Default";
         return Arrays.stream(aClass.getAllFields())
                 .filter(field -> {
-                    final Stream<PsiAnnotation> annotations = Arrays.stream(field.getAnnotations());
+                    final PsiAnnotation[] annotations = field.getAnnotations();
                     final PsiModifierList modifiers = field.getModifierList();
                     final boolean isStaticField = modifiers != null && modifiers.hasModifierProperty(PsiModifier.STATIC);
                     return !isStaticField
-                            && annotations.anyMatch(annotation -> nonNullAnnotations.contains(annotation.getQualifiedName()))
-                            && annotations.noneMatch(annotation ->
+                            && Arrays.stream(annotations).anyMatch(annotation -> nonNullAnnotations.contains(annotation.getQualifiedName()))
+                            && Arrays.stream(annotations).noneMatch(annotation ->
                                 Objects.equals(annotation.getQualifiedName(), defaultBuilderValueAnnotation));
                 })
                 .map(PsiField::getName)

--- a/src/main/java/com/dguner/lombokbuilderhelper/LombokBuilderInspection.java
+++ b/src/main/java/com/dguner/lombokbuilderhelper/LombokBuilderInspection.java
@@ -7,17 +7,7 @@ import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.codeInspection.ProblemsHolder;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
-import com.intellij.psi.JavaElementVisitor;
-import com.intellij.psi.JavaPsiFacade;
-import com.intellij.psi.PsiClass;
-import com.intellij.psi.PsiElement;
-import com.intellij.psi.PsiElementFactory;
-import com.intellij.psi.PsiElementVisitor;
-import com.intellij.psi.PsiField;
-import com.intellij.psi.PsiLocalVariable;
-import com.intellij.psi.PsiMethod;
-import com.intellij.psi.PsiMethodCallExpression;
-import com.intellij.psi.PsiReference;
+import com.intellij.psi.*;
 import com.intellij.psi.impl.source.tree.java.PsiIdentifierImpl;
 import com.intellij.psi.impl.source.tree.java.PsiMethodCallExpressionImpl;
 import com.intellij.psi.impl.source.tree.java.PsiReferenceExpressionImpl;
@@ -31,6 +21,8 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.jetbrains.annotations.NotNull;
 
 public class LombokBuilderInspection extends AbstractBaseJavaLocalInspectionTool {
@@ -109,10 +101,15 @@ public class LombokBuilderInspection extends AbstractBaseJavaLocalInspectionTool
         final Set<String> nonNullAnnotations = Set.of("lombok.NonNull", "org.jetbrains.annotations.NotNull");
         final String defaultBuilderValueAnnotation = "lombok.Builder.Default";
         return Arrays.stream(aClass.getAllFields())
-                .filter(field -> Arrays.stream(field.getAnnotations())
-                        .anyMatch(annotation -> nonNullAnnotations.contains(annotation.getQualifiedName())))
-                .filter(field -> Arrays.stream(field.getAnnotations())
-                        .noneMatch(annotation -> Objects.equals(annotation.getQualifiedName(), defaultBuilderValueAnnotation)))
+                .filter(field -> {
+                    final Stream<PsiAnnotation> annotations = Arrays.stream(field.getAnnotations());
+                    final PsiModifierList modifiers = field.getModifierList();
+                    final boolean isStaticField = modifiers != null && modifiers.hasModifierProperty(PsiModifier.STATIC);
+                    return !isStaticField
+                            && annotations.anyMatch(annotation -> nonNullAnnotations.contains(annotation.getQualifiedName()))
+                            && annotations.noneMatch(annotation ->
+                                Objects.equals(annotation.getQualifiedName(), defaultBuilderValueAnnotation));
+                })
                 .map(PsiField::getName)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/dguner/lombokbuilderhelper/LombokBuilderInspection.java
+++ b/src/main/java/com/dguner/lombokbuilderhelper/LombokBuilderInspection.java
@@ -100,16 +100,19 @@ public class LombokBuilderInspection extends AbstractBaseJavaLocalInspectionTool
     }
 
     private boolean isClassBuilder(PsiClass aClass) {
+        final Set<String> builderClassQualifiedNames = Set.of("lombok.Builder", "lombok.experimental.SuperBuilder");
         return Arrays.stream(aClass.getAnnotations())
-                .anyMatch(annotation -> Objects.equals(annotation.getQualifiedName(),
-                        "lombok.Builder"));
+                .anyMatch(annotation -> builderClassQualifiedNames.contains(annotation.getQualifiedName()));
     }
 
     private List<String> getMandatoryFields(PsiClass aClass) {
+        final Set<String> nonNullAnnotations = Set.of("lombok.NonNull", "org.jetbrains.annotations.NotNull");
+        final String defaultBuilderValueAnnotation = "lombok.Builder.Default";
         return Arrays.stream(aClass.getAllFields())
                 .filter(field -> Arrays.stream(field.getAnnotations())
-                        .anyMatch(annotation -> Objects.equals(annotation.getQualifiedName(),
-                                "lombok.NonNull")))
+                        .anyMatch(annotation -> nonNullAnnotations.contains(annotation.getQualifiedName())))
+                .filter(field -> Arrays.stream(field.getAnnotations())
+                        .noneMatch(annotation -> Objects.equals(annotation.getQualifiedName(), defaultBuilderValueAnnotation)))
                 .map(PsiField::getName)
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
First of all, thank you so much for this very needed plugin!

I extended it's logic, so it supports 3 additional features:
1. Identifying `org.jetbrains.annotations.NotNull` as an annotation for a required field.
2. Identifying `SuperBuilder`, as an equivalent of `Builder`.
3. Ignoring non-null fields that have a default value, assuming it's annotated by `@Builder.Default`.
4. Ignoring static fields.